### PR TITLE
Update layout.jade

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     title express-upload-progress


### PR DESCRIPTION
`doctype 5` is deprecated, you must now use `doctype html`
